### PR TITLE
Link to godoc in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Documentation](https://godoc.org/github.com/librespot-org/librespot-golang/librespot?status.svg)](https://godoc.org/github.com/librespot-org/librespot-golang/librespot)
 ## librespot-golang
 
 ### Introduction


### PR DESCRIPTION
I think it would be helpful to have a link to the godoc reference in the ReadMe, as is standard for most go packages